### PR TITLE
add guile 3.0 support and fix warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_ARG_WITH([guilesitedir],
              esac],
              [guilesitedir=""])
 
-GUILE_PKG([2.2 2.0])
+GUILE_PKG([3.0 2.2 2.0])
 GUILE_PROGS
 GUILE_SITE_DIR
 

--- a/modules/gitlab/cli/common.scm
+++ b/modules/gitlab/cli/common.scm
@@ -1,4 +1,5 @@
 (define-module (gitlab cli common)
+  #:use-module (ice-9 format)
   #:use-module (ice-9 pretty-print)
   #:export (print
             print-many


### PR DESCRIPTION
I haven't fully tried it. But it builds fine and `gitlab-cli` seems to show some usage help.

Just added it to homebrew-guile.